### PR TITLE
Updated to make WorkExecutedEvent\AddedJobResponseRecord a [0..*] option

### DIFF
--- a/B2MML-ProcessEvents.xsd
+++ b/B2MML-ProcessEvents.xsd
@@ -1925,7 +1925,7 @@
       <xsd:element name="HierarchyScope" type="HierarchyScopeType" minOccurs="0" maxOccurs="1" />
       <xsd:element name="EventTimestamp" type="xsd:dateTime" minOccurs="0" maxOccurs="1" />
       <xsd:element name="EventEffectiveTime" type="xsd:dateTime" minOccurs="0" maxOccurs="1" />
-      <xsd:element name="AddedJobResponseRecord">
+      <xsd:element name="AddedJobResponseRecord" minOccurs="0" maxOccurs="unbounded">
         <xsd:complexType>
           <xsd:sequence>
             <xsd:element name="JobResponse" type="JobResponseType" />

--- a/B2MML-ProcessEvents.xsd
+++ b/B2MML-ProcessEvents.xsd
@@ -2068,28 +2068,28 @@
       <xsd:element name="HierarchyScope" type="HierarchyScopeType" minOccurs="0" maxOccurs="1" />
       <xsd:element name="EventTimestamp" type="xsd:dateTime" minOccurs="0" maxOccurs="1" />
       <xsd:element name="EventEffectiveTime" type="xsd:dateTime" minOccurs="0" maxOccurs="1" />
-      <xsd:element name="AddedJobResponseRecord" minOccurs="0" maxOccurs="unbounded">
+      <xsd:element name="AddedJobResponseRecord">
         <xsd:complexType>
           <xsd:sequence>
-            <xsd:element name="JobResponse" type="JobResponseType" minOccurs="1" maxOccurs="unbounded"/>
+            <xsd:element name="JobResponse" type="JobResponseType" minOccurs="0" maxOccurs="unbounded"/>
           </xsd:sequence>
           <xsd:attribute name="recordTimestamp" type="xsd:dateTime" />
           <xsd:attribute name="effectiveTimestamp" type="xsd:dateTime" />
         </xsd:complexType>
       </xsd:element>
-      <xsd:element name="ChangedJobResponseRecord" minOccurs="0" maxOccurs="unbounded">
+      <xsd:element name="ChangedJobResponseRecord">
         <xsd:complexType>
           <xsd:sequence>
-            <xsd:element name="JobResponse" type="JobResponseType" minOccurs="1" maxOccurs="unbounded"/>
+            <xsd:element name="JobResponse" type="JobResponseType" minOccurs="0" maxOccurs="unbounded"/>
           </xsd:sequence>
           <xsd:attribute name="recordTimestamp" type="xsd:dateTime" />
           <xsd:attribute name="effectiveTimestamp" type="xsd:dateTime" />
         </xsd:complexType>
       </xsd:element>
-      <xsd:element name="DeletedJobResponseRecord" minOccurs="0" maxOccurs="unbounded">
+      <xsd:element name="DeletedJobResponseRecord">
         <xsd:complexType>
           <xsd:sequence>
-            <xsd:element name="JobResponse" type="JobResponseType" minOccurs="1" maxOccurs="unbounded"/>
+            <xsd:element name="JobResponse" type="JobResponseType" minOccurs="0" maxOccurs="unbounded"/>
           </xsd:sequence>
           <xsd:attribute name="recordTimestamp" type="xsd:dateTime" />
           <xsd:attribute name="effectiveTimestamp" type="xsd:dateTime" />

--- a/B2MML-ProcessEvents.xsd
+++ b/B2MML-ProcessEvents.xsd
@@ -1928,7 +1928,7 @@
       <xsd:element name="AddedJobResponseRecord" minOccurs="0" maxOccurs="unbounded">
         <xsd:complexType>
           <xsd:sequence>
-            <xsd:element name="JobResponse" type="JobResponseType" />
+            <xsd:element name="JobResponse" type="JobResponseType" minOccurs="1" maxOccurs="unbounded"/>
           </xsd:sequence>
           <xsd:attribute name="recordTimestamp" type="xsd:dateTime" />
           <xsd:attribute name="effectiveTimestamp" type="xsd:dateTime" />
@@ -2068,28 +2068,28 @@
       <xsd:element name="HierarchyScope" type="HierarchyScopeType" minOccurs="0" maxOccurs="1" />
       <xsd:element name="EventTimestamp" type="xsd:dateTime" minOccurs="0" maxOccurs="1" />
       <xsd:element name="EventEffectiveTime" type="xsd:dateTime" minOccurs="0" maxOccurs="1" />
-      <xsd:element name="AddedJobResponseRecord">
+      <xsd:element name="AddedJobResponseRecord" minOccurs="0" maxOccurs="unbounded">
         <xsd:complexType>
           <xsd:sequence>
-            <xsd:element name="JobResponse" type="JobResponseType" minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element name="JobResponse" type="JobResponseType" minOccurs="1" maxOccurs="unbounded"/>
           </xsd:sequence>
           <xsd:attribute name="recordTimestamp" type="xsd:dateTime" />
           <xsd:attribute name="effectiveTimestamp" type="xsd:dateTime" />
         </xsd:complexType>
       </xsd:element>
-      <xsd:element name="ChangedJobResponseRecord">
+      <xsd:element name="ChangedJobResponseRecord" minOccurs="0" maxOccurs="unbounded">
         <xsd:complexType>
           <xsd:sequence>
-            <xsd:element name="JobResponse" type="JobResponseType" minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element name="JobResponse" type="JobResponseType" minOccurs="1" maxOccurs="unbounded"/>
           </xsd:sequence>
           <xsd:attribute name="recordTimestamp" type="xsd:dateTime" />
           <xsd:attribute name="effectiveTimestamp" type="xsd:dateTime" />
         </xsd:complexType>
       </xsd:element>
-      <xsd:element name="DeletedJobResponseRecord">
+      <xsd:element name="DeletedJobResponseRecord" minOccurs="0" maxOccurs="unbounded">
         <xsd:complexType>
           <xsd:sequence>
-            <xsd:element name="JobResponse" type="JobResponseType" minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element name="JobResponse" type="JobResponseType" minOccurs="1" maxOccurs="unbounded"/>
           </xsd:sequence>
           <xsd:attribute name="recordTimestamp" type="xsd:dateTime" />
           <xsd:attribute name="effectiveTimestamp" type="xsd:dateTime" />


### PR DESCRIPTION
systems should be able to post more than 1 JobResponseRecord when reporting work that has been executed if they wish to package this data into a single message.